### PR TITLE
Add @maxw's faster byte array retrieval method to generator. 

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -403,6 +403,8 @@ class Builder(object):
             x = s.encode(encoding, errors)
         elif isinstance(s, compat.binary_types):
             x = s
+        elif isinstance(s, bytearray):
+            x = s
         else:
             raise TypeError("non-string passed to CreateString")
 

--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -403,8 +403,6 @@ class Builder(object):
             x = s.encode(encoding, errors)
         elif isinstance(s, compat.binary_types):
             x = s
-        elif isinstance(s, bytearray):
-            x = s
         else:
             raise TypeError("non-string passed to CreateString")
 
@@ -419,23 +417,23 @@ class Builder(object):
 
         return self.EndVector(len(x))
 
-    def CreateByteArray(self, bytes):
-        """CreateByteArray writes a bytearray from the given bytearray."""
+    def CreateByteArray(self, bts):
+        """CreateByteArray writes a bytearray from the given bytearray or bytes."""
 
         self.assertNotNested()
         ## @cond FLATBUFFERS_INTERNAL
         self.nested = True
         ## @endcond
 
-        if isinstance(bytes, bytearray):
-            x = bytes
+        if isinstance(bts, bytearray) or isinstance(bts, bytes):
+            x = bts
         else:
-            raise TypeError("non-bytearray passed to CreateByteArray")
+            raise TypeError("non-bytearray or bytes passed to CreateByteArray")
 
         self.Prep(N.UOffsetTFlags.bytewidth, (len(x)+1)*N.Uint8Flags.bytewidth)
         self.Place(0, N.Uint8Flags)
 
-        l = UOffsetTFlags.py_type(len(bytes))
+        l = UOffsetTFlags.py_type(len(bts))
         ## @cond FLATBUFFERS_INTERNAL
         self.head = UOffsetTFlags.py_type(self.Head() - l)
         ## @endcond

--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -419,6 +419,30 @@ class Builder(object):
 
         return self.EndVector(len(x))
 
+    def CreateByteArray(self, bytes):
+        """CreateByteArray writes a bytearray from the given bytearray."""
+
+        self.assertNotNested()
+        ## @cond FLATBUFFERS_INTERNAL
+        self.nested = True
+        ## @endcond
+
+        if isinstance(bytes, bytearray):
+            x = bytes
+        else:
+            raise TypeError("non-bytearray passed to CreateByteArray")
+
+        self.Prep(N.UOffsetTFlags.bytewidth, (len(x)+1)*N.Uint8Flags.bytewidth)
+        self.Place(0, N.Uint8Flags)
+
+        l = UOffsetTFlags.py_type(len(bytes))
+        ## @cond FLATBUFFERS_INTERNAL
+        self.head = UOffsetTFlags.py_type(self.Head() - l)
+        ## @endcond
+        self.Bytes[self.Head():self.Head()+l] = x
+
+        return self.EndVector(len(x))
+
     ## @cond FLATBUFFERS_INTERNAL
     def assertNested(self):
         """

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -274,6 +274,22 @@ static void GetMemberOfVectorOfNonStruct(const StructDef &struct_def,
   code += "\n";
 }
 
+// Get the value of a vector's non-struct as a bytearray.
+static void GetMemberOfVectorOfNonStructBytes(const StructDef &struct_def,
+                                         const FieldDef &field,
+                                         std::string *code_ptr) {
+  std::string &code = *code_ptr;
+
+  GenReceiver(struct_def, code_ptr);
+  code += MakeCamel(field.name);
+  code += "Bytes";
+  code += "(self):";
+  code += OffsetPrefix(field);
+  code += Indent + Indent + Indent + "return self._tab.String(o + self._tab.Pos)\n";
+  code += Indent + Indent + "return \"\"\n";
+  code += "\n";
+}
+
 // Begin the creator function signature.
 static void BeginBuilderArgs(const StructDef &struct_def,
                              std::string *code_ptr) {
@@ -440,6 +456,7 @@ static void GenStructAccessor(const StructDef &struct_def,
           GetMemberOfVectorOfStruct(struct_def, field, code_ptr);
         } else {
           GetMemberOfVectorOfNonStruct(struct_def, field, code_ptr);
+          GetMemberOfVectorOfNonStructBytes(struct_def, field, code_ptr);
         }
         break;
       }

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -286,7 +286,7 @@ static void GetMemberOfVectorOfNonStructByteArray(const StructDef &struct_def,
   code += "(self):";
   code += OffsetPrefix(field);
   // Grab the sub bytearray from the main bytearray starting at the offset and ending at the length + offset.
-  code += Indent + Indent + Indent + "self._tab.Bytes[self._tab.Vector(o):(self._tab.VectorLen(o) + self._tab.Vector(o))]\n";
+  code += Indent + Indent + Indent + "return self._tab.Bytes[self._tab.Vector(o):(self._tab.VectorLen(o) + self._tab.Vector(o))]\n";
   code += Indent + Indent + "return \"\"\n";
   code += "\n";
 }

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -275,17 +275,17 @@ static void GetMemberOfVectorOfNonStruct(const StructDef &struct_def,
 }
 
 // Get the value of a vector's non-struct as a bytearray.
-static void GetMemberOfVectorOfNonStructBytes(const StructDef &struct_def,
-                                         const FieldDef &field,
-                                         std::string *code_ptr) {
+static void GetMemberOfVectorOfNonStructByteArray(const StructDef &struct_def,
+                                                  const FieldDef &field,
+                                                  std::string *code_ptr) {
   std::string &code = *code_ptr;
 
   GenReceiver(struct_def, code_ptr);
   code += MakeCamel(field.name);
-  code += "Bytes";
+  code += "ByteArray";
   code += "(self):";
   code += OffsetPrefix(field);
-  code += Indent + Indent + Indent + "return self._tab.String(o + self._tab.Pos)\n";
+  code += Indent + Indent + Indent + "return bytearray(self._tab.Bytes)[self._tab.Vector(o):][:self._tab.VectorLen(o)]\n";
   code += Indent + Indent + "return \"\"\n";
   code += "\n";
 }
@@ -456,7 +456,7 @@ static void GenStructAccessor(const StructDef &struct_def,
           GetMemberOfVectorOfStruct(struct_def, field, code_ptr);
         } else {
           GetMemberOfVectorOfNonStruct(struct_def, field, code_ptr);
-          GetMemberOfVectorOfNonStructBytes(struct_def, field, code_ptr);
+          GetMemberOfVectorOfNonStructByteArray(struct_def, field, code_ptr);
         }
         break;
       }

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -285,7 +285,7 @@ static void GetMemberOfVectorOfNonStructByteArray(const StructDef &struct_def,
   code += "ByteArray";
   code += "(self):";
   code += OffsetPrefix(field);
-  code += Indent + Indent + Indent + "return bytearray(self._tab.Bytes)[self._tab.Vector(o):][:self._tab.VectorLen(o)]\n";
+  code += Indent + Indent + Indent + "return self._tab.Bytes[self._tab.Vector(o):][:self._tab.VectorLen(o)]\n";
   code += Indent + Indent + "return \"\"\n";
   code += "\n";
 }

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -285,7 +285,8 @@ static void GetMemberOfVectorOfNonStructByteArray(const StructDef &struct_def,
   code += "ByteArray";
   code += "(self):";
   code += OffsetPrefix(field);
-  code += Indent + Indent + Indent + "return self._tab.Bytes[self._tab.Vector(o):][:self._tab.VectorLen(o)]\n";
+  // Grab the sub bytearray from the main bytearray starting at the offset and ending at the length + offset.
+  code += Indent + Indent + Indent + "self._tab.Bytes[self._tab.Vector(o):(self._tab.VectorLen(o) + self._tab.Vector(o))]\n";
   code += Indent + Indent + "return \"\"\n";
   code += "\n";
 }


### PR DESCRIPTION
I looked into other possible solutions for this, but ended up just making it so the code you initially quickly hacked in would work the next time we ran the generator. It generated the same code as the handwritten one when I ran it with these changes.

Here's the commit message:
This adds a an additional getter method for vectors with a 'Bytes' suffix.

So if you have:
 table Foo {
   data:[ubyte];
 }

it will generate two accessors:
 def Data(self, j):
 def DataBytes(self):

The second one which grabs the whole vector so you don't have to loop
through them to build it.